### PR TITLE
update: 壁抜けバグ修正、およびプレイヤーの動きを座標移動にするよう修正

### DIFF
--- a/Assets/Scenes/Play.unity
+++ b/Assets/Scenes/Play.unity
@@ -333,7 +333,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 598c8a0f33bf044c1bce50504b2f7f43, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  speed: 3
+  speed: 5
 --- !u!50 &475216656
 Rigidbody2D:
   serializedVersion: 4

--- a/Assets/Scripts/PlayerManager.cs
+++ b/Assets/Scripts/PlayerManager.cs
@@ -5,8 +5,10 @@ using UnityEngine;
 public class PlayerManager : MonoBehaviour
 {
   // プレイヤーの移動の速さ
-  public float speed = 10f;
+  public float speed = 5f;
   Rigidbody2D myRigidBody2d;
+
+  Transform tf;
 
   private float deltaX, deltaY;
 
@@ -14,6 +16,7 @@ public class PlayerManager : MonoBehaviour
   void Start()
   {
     myRigidBody2d = GetComponent<Rigidbody2D>();
+    tf = GetComponent<Transform>();
   }
 
   // Update is called once per frame
@@ -34,32 +37,41 @@ public class PlayerManager : MonoBehaviour
       }
     }
 
-    // プレイヤーの移動(スマホでのタッチ操作)
+
+    Vector2 direction = new Vector2(0, 0);
+
     if (Input.touchCount > 0)
     {
-      // タッチ情報の取得
       Touch touch = Input.GetTouch(0);
-
       Vector2 touchPos = Camera.main.ScreenToWorldPoint(touch.position);
 
       switch (touch.phase)
       {
         case TouchPhase.Began:
-          Debug.Log(touch.phase);
-          Debug.Log(touchPos);
-          deltaX = touchPos.x - transform.position.x;
-          deltaY = touchPos.y - transform.position.y;
+          // 画面に指が触れた時
+          this.transform.position = touchPos;
           break;
-
         case TouchPhase.Moved:
-          myRigidBody2d.MovePosition(new Vector2(touchPos.x - deltaX, touchPos.y - deltaY));
-          Debug.Log(this.transform.position);
-          break;
-
-        case TouchPhase.Ended:
-          myRigidBody2d.velocity = Vector2.zero;
+          // 指を動かしている時
+          this.transform.position = new Vector2(transform.position.x + touchPos.x * speed, -3);
           break;
       }
+
+      // プレイヤーの座標の取得と移動量
+      Vector2 pos = this.transform.position;
+      // pos += directions * speed * Time.deltaTime;
+      pos = new Vector2(touchPos.x, -3);
+
+      if (pos.x > 1.8)
+      {
+        pos.x = 1.8f;
+      }
+      else if (pos.x < -1.8)
+      {
+        pos.x = -1.8f;
+      }
+      // プレイヤーの新規位置とする
+      transform.position = pos;
     }
   }
 }

--- a/Backup/Assets/Scenes/Play.unity
+++ b/Backup/Assets/Scenes/Play.unity
@@ -333,7 +333,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 598c8a0f33bf044c1bce50504b2f7f43, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  speed: 3
+  speed: 5
 --- !u!50 &475216656
 Rigidbody2D:
   serializedVersion: 4


### PR DESCRIPTION
### 対象issue
#2 
#20 

### 変更内容
- 壁抜けバグを修正
  - x座標が`-1.8`から`1.8`の間で動くことしかできないように修正
- プレイヤーの移動処理を座標移動に修正
  - 元々`Rigidbody2D`を使って物理演算で処理を実装していたが、`transform.position`を用いた座標移動の処理にした
    - もたつきを軽減